### PR TITLE
Refactor ezauth into a plug-and-play library

### DIFF
--- a/cmd/ezauthapi/main.go
+++ b/cmd/ezauthapi/main.go
@@ -1,17 +1,30 @@
 package main
 
 import (
+	"log"
+
+	"github.com/josuebrunel/ezauth"
 	"github.com/josuebrunel/ezauth/pkg/config"
-	"github.com/josuebrunel/ezauth/pkg/handler"
-	"github.com/josuebrunel/ezauth/pkg/service"
 	"github.com/josuebrunel/gopkg/xlog"
 )
 
 func main() {
-	cfg := config.V
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
 	xlog.Info("config", "cfg", cfg)
-	auth := service.New(&cfg)
-	handler := handler.New(auth, "auth")
+	auth, err := ezauth.New(&cfg, "auth")
+	if err != nil {
+		log.Fatalf("failed to initialize ezauth: %v", err)
+	}
+
+	// In standalone mode, we might want to run migrations automatically
+	if err := auth.Migrate(); err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+	}
+
 	xlog.Info("starting server")
-	handler.Run()
+	auth.Handler.Run()
 }

--- a/ezauth.go
+++ b/ezauth.go
@@ -1,0 +1,70 @@
+package ezauth
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+
+	"github.com/josuebrunel/ezauth/pkg/config"
+	"github.com/josuebrunel/ezauth/pkg/db/migrations"
+	"github.com/josuebrunel/ezauth/pkg/db/repository"
+	"github.com/josuebrunel/ezauth/pkg/handler"
+	"github.com/josuebrunel/ezauth/pkg/service"
+)
+
+type EzAuth struct {
+	Config  *config.Config
+	Repo    *repository.Repository
+	Service *service.Auth
+	Handler *handler.Handler
+}
+
+// New creates a new EzAuth instance from a config. It handles database connection.
+func New(cfg *config.Config, path string) (*EzAuth, error) {
+	repo, err := repository.Open(repository.Opts{
+		Dialect: cfg.DB.Dialect,
+		DSN:     cfg.DB.DSN,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	svc := service.New(cfg, repo)
+	h := handler.New(svc, path)
+
+	return &EzAuth{
+		Config:  cfg,
+		Repo:    repo,
+		Service: svc,
+		Handler: h,
+	}, nil
+}
+
+// NewWithDB creates a new EzAuth instance using an existing database connection.
+func NewWithDB(cfg *config.Config, db *sql.DB, path string) (*EzAuth, error) {
+	repo := repository.New(db, cfg.DB.Dialect)
+	svc := service.New(cfg, repo)
+	h := handler.New(svc, path)
+
+	return &EzAuth{
+		Config:  cfg,
+		Repo:    repo,
+		Service: svc,
+		Handler: h,
+	}, nil
+}
+
+// Migrate runs the database migrations.
+func (e *EzAuth) Migrate() error {
+	return migrations.MigrateUpWithDBConn(e.Repo.DB(), e.Repo.Opts.Dialect)
+}
+
+// AuthMiddleware returns the authentication middleware.
+func (e *EzAuth) AuthMiddleware(next http.Handler) http.Handler {
+	return e.Handler.AuthMiddleware(next)
+}
+
+// GetUserID retrieves the user ID from the request context.
+func (e *EzAuth) GetUserID(ctx context.Context) (string, error) {
+	return handler.GetUserID(ctx)
+}

--- a/ezauth_test.go
+++ b/ezauth_test.go
@@ -1,0 +1,35 @@
+package ezauth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/josuebrunel/ezauth/pkg/config"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestEzAuth(t *testing.T) {
+	dsn := fmt.Sprintf("file:%d?mode=memory&cache=shared", time.Now().UnixNano())
+	cfg := &config.Config{
+		DB: config.Database{
+			Dialect: "sqlite3",
+			DSN:     dsn,
+		},
+		JWTSecret: "test-secret",
+	}
+
+	t.Run("New", func(t *testing.T) {
+		auth, err := New(cfg, "auth")
+		if err != nil {
+			t.Fatalf("failed to create ezauth: %v", err)
+		}
+		if auth == nil {
+			t.Fatal("expected ezauth instance, got nil")
+		}
+
+		if err := auth.Migrate(); err != nil {
+			t.Fatalf("failed to migrate: %v", err)
+		}
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,15 +53,13 @@ type Config struct {
 	TimeOut   time.Duration `json:"timeout" env:"TIMEOUT" default:"30s"`
 }
 
-var V Config
-
-func init() {
+func LoadConfig() (Config, error) {
 	var cfg Config
 
 	if err := xenv.LoadWithOptions(&cfg, xenv.Options{Prefix: "EZAUTH_"}); err != nil {
 		xlog.Error("failed to load config", "err", err)
-		panic(err)
+		return cfg, err
 	}
 
-	V = cfg
+	return cfg, nil
 }

--- a/pkg/db/repository/repository.go
+++ b/pkg/db/repository/repository.go
@@ -52,16 +52,24 @@ type Repository struct {
 	IQueryAdapter
 }
 
-func New(opts Opts) *Repository {
-	qAdapter := getDialectQuery(opts.Dialect)
-	db := util.Must(getDBConnection(opts))
+func New(db *sql.DB, dialect string) *Repository {
+	qAdapter := getDialectQuery(dialect)
 	bdb := bob.NewDB(db)
 
 	return &Repository{
 		db:            db,
 		bdb:           bdb,
 		IQueryAdapter: qAdapter,
+		Opts:          Opts{Dialect: dialect},
 	}
+}
+
+func Open(opts Opts) (*Repository, error) {
+	db, err := getDBConnection(opts)
+	if err != nil {
+		return nil, err
+	}
+	return New(db, opts.Dialect), nil
 }
 
 func (r Repository) DB() *sql.DB {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -27,7 +27,10 @@ func setupTestHandler(t *testing.T) *Handler {
 		JWTSecret: "test-secret",
 		Addr:      ":8080",
 	}
-	authSvc := service.New(cfg)
+	authSvc, err := service.NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create auth service: %v", err)
+	}
 
 	// Run migrations
 	if err := migrations.MigrateUpWithDBConn(authSvc.Repo.DB(), "sqlite3"); err != nil {

--- a/pkg/service/basicauth_test.go
+++ b/pkg/service/basicauth_test.go
@@ -22,7 +22,10 @@ func setupBasicAuthTestDB(t *testing.T) *Auth {
 		},
 		JWTSecret: "test-secret",
 	}
-	auth := New(cfg)
+	auth, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create auth service: %v", err)
+	}
 
 	// Run migrations to set up the schema
 	if err := migrations.MigrateUpWithDBConn(auth.Repo.DB(), "sqlite"); err != nil {

--- a/pkg/service/oauth2_authenticate_test.go
+++ b/pkg/service/oauth2_authenticate_test.go
@@ -18,7 +18,10 @@ func setupOAuth2AuthTestDB(t *testing.T) *Auth {
 		},
 		JWTSecret: "test-secret",
 	}
-	auth := New(cfg)
+	auth, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create auth service: %v", err)
+	}
 	if err := migrations.MigrateUpWithDBConn(auth.Repo.DB(), "sqlite"); err != nil {
 		t.Fatalf("failed to run migrations: %v", err)
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -10,13 +10,20 @@ type Auth struct {
 	Repo *repository.Repository
 }
 
-func New(cfg *config.Config) *Auth {
-	repo := repository.New(repository.Opts{
-		Dialect: cfg.DB.Dialect,
-		DSN:     cfg.DB.DSN,
-	})
+func New(cfg *config.Config, repo *repository.Repository) *Auth {
 	return &Auth{
 		Cfg:  cfg,
 		Repo: repo,
 	}
+}
+
+func NewFromConfig(cfg *config.Config) (*Auth, error) {
+	repo, err := repository.Open(repository.Opts{
+		Dialect: cfg.DB.Dialect,
+		DSN:     cfg.DB.DSN,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg, repo), nil
 }

--- a/pkg/service/token_test.go
+++ b/pkg/service/token_test.go
@@ -23,7 +23,10 @@ func setupTestDB(t *testing.T) *Auth {
 		},
 		JWTSecret: "test-secret",
 	}
-	auth := New(cfg)
+	auth, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create auth service: %v", err)
+	}
 
 	// Run migrations to set up the schema
 	if err := migrations.MigrateUpWithDBConn(auth.Repo.DB(), "sqlite3"); err != nil {


### PR DESCRIPTION
The goal of this refactor was to make `ezauth` a "plug and play" authentication library for Go. I introduced a unified entry point in the root package, removed global state and side-effecting `init()` functions, and improved dependency injection throughout the service, repository, and handler layers. This allows users to easily embed `ezauth` into their applications, use existing database connections, and control when and how the library is initialized and migrated.

---
*PR created automatically by Jules for task [3897623910038061673](https://jules.google.com/task/3897623910038061673) started by @josuebrunel*