### PR TITLE
Refactor errors and repository querier naming

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,6 +1,8 @@
 # Global Settings
 EZAUTH_ADDR=":8080"
+EZAUTH_BASE_URL="http://localhost:8080"
 EZAUTH_DEBUG=false
+EZAUTH_SECRET="your-app-secret"
 EZAUTH_JWT_SECRET="your-super-secret-key"
 EZAUTH_TIMEOUT="30s"
 
@@ -28,3 +30,10 @@ EZAUTH_OAUTH2_FACEBOOK_CLIENT_ID="your-facebook-client-id"
 EZAUTH_OAUTH2_FACEBOOK_CLIENT_SECRET="your-facebook-client-secret"
 EZAUTH_OAUTH2_FACEBOOK_REDIRECT_URL="http://localhost:8080/auth/oauth2/facebook/callback"
 EZAUTH_OAUTH2_FACEBOOK_SCOPES="email"
+
+# SMTP Settings
+EZAUTH_SMTP_HOST=""
+EZAUTH_SMTP_PORT=587
+EZAUTH_SMTP_USER=""
+EZAUTH_SMTP_PASSWORD=""
+EZAUTH_SMTP_FROM="noreply@example.com"

--- a/pkg/db/repository/postgres/query.go
+++ b/pkg/db/repository/postgres/query.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stephenafamo/bob/dialect/psql/um"
 )
 
-type PSQLQueryAdapter struct {
+type PSQLQuerier struct {
 }
 
-func (q *PSQLQueryAdapter) QueryUserInsert(ctx context.Context, user *models.User) bob.Query {
+func (q *PSQLQuerier) QueryUserInsert(ctx context.Context, user *models.User) bob.Query {
 	return psql.Insert(
 		im.Into(psql.Quote(models.TableUser),
 			models.ColumnEmail,
@@ -44,15 +44,15 @@ func (q *PSQLQueryAdapter) QueryUserInsert(ctx context.Context, user *models.Use
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryUserGetByEmail(ctx context.Context, email string) bob.Query {
+func (q *PSQLQuerier) QueryUserGetByEmail(ctx context.Context, email string) bob.Query {
 	return psql.Select(sm.From(psql.Quote(models.TableUser)), sm.Where(psql.Quote(models.ColumnEmail).EQ(psql.Arg(email))))
 }
 
-func (q *PSQLQueryAdapter) QueryUserGetByID(ctx context.Context, id string) bob.Query {
+func (q *PSQLQuerier) QueryUserGetByID(ctx context.Context, id string) bob.Query {
 	return psql.Select(sm.From(psql.Quote(models.TableUser)), sm.Where(psql.Quote("id").EQ(psql.Arg(id))))
 }
 
-func (q *PSQLQueryAdapter) QueryUserGetByProvider(ctx context.Context, provider, providerID string) bob.Query {
+func (q *PSQLQuerier) QueryUserGetByProvider(ctx context.Context, provider, providerID string) bob.Query {
 	return psql.Select(
 		sm.From(psql.Quote(models.TableUser)),
 		sm.Where(
@@ -62,7 +62,7 @@ func (q *PSQLQueryAdapter) QueryUserGetByProvider(ctx context.Context, provider,
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryUserUpdate(ctx context.Context, user *models.User) bob.Query {
+func (q *PSQLQuerier) QueryUserUpdate(ctx context.Context, user *models.User) bob.Query {
 	qm := []bob.Mod[*dialect.UpdateQuery]{
 		um.Table(psql.Quote(models.TableUser)),
 		um.Where(psql.Quote("id").EQ(psql.Arg(user.ID))),
@@ -103,15 +103,15 @@ func (q *PSQLQueryAdapter) QueryUserUpdate(ctx context.Context, user *models.Use
 	return psql.Update(qm...)
 }
 
-func (q *PSQLQueryAdapter) QueryUserCheckPasswordHash(ctx context.Context, email, passwordHash string) bob.Query {
+func (q *PSQLQuerier) QueryUserCheckPasswordHash(ctx context.Context, email, passwordHash string) bob.Query {
 	return psql.Select(sm.From(psql.Quote(models.TableUser)), sm.Where(psql.Quote(models.ColumnEmail).EQ(psql.Arg(email)).And(psql.Quote(models.ColumnPasswordHash).EQ(psql.Arg(passwordHash)))))
 }
 
-func (q *PSQLQueryAdapter) QueryUserDelete(ctx context.Context, id string) bob.Query {
+func (q *PSQLQuerier) QueryUserDelete(ctx context.Context, id string) bob.Query {
 	return psql.Delete(dm.From(psql.Quote(models.TableUser)), dm.Where(psql.Quote("id").EQ(psql.Arg(id))))
 }
 
-func (q *PSQLQueryAdapter) QueryTokenInsert(ctx context.Context, token *models.Token) bob.Query {
+func (q *PSQLQuerier) QueryTokenInsert(ctx context.Context, token *models.Token) bob.Query {
 	return psql.Insert(
 		im.Into(psql.Quote(models.TableToken),
 			models.ColumnUserID,
@@ -134,15 +134,15 @@ func (q *PSQLQueryAdapter) QueryTokenInsert(ctx context.Context, token *models.T
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryTokenGetByID(ctx context.Context, id string) bob.Query {
+func (q *PSQLQuerier) QueryTokenGetByID(ctx context.Context, id string) bob.Query {
 	return psql.Select(sm.From(psql.Quote(models.TableToken)), sm.Where(psql.Quote("id").EQ(psql.Arg(id))))
 }
 
-func (q *PSQLQueryAdapter) QueryTokenGetByToken(ctx context.Context, token string) bob.Query {
+func (q *PSQLQuerier) QueryTokenGetByToken(ctx context.Context, token string) bob.Query {
 	return psql.Select(sm.From(psql.Quote(models.TableToken)), sm.Where(psql.Quote(models.ColumnToken).EQ(psql.Arg(token))))
 }
 
-func (q *PSQLQueryAdapter) QueryTokenRevoke(ctx context.Context, id string) bob.Query {
+func (q *PSQLQuerier) QueryTokenRevoke(ctx context.Context, id string) bob.Query {
 	return psql.Update(
 		um.Table(psql.Quote(models.TableToken)),
 		um.SetCol(psql.Quote(models.ColumnRevoked).String()).To(true),
@@ -150,11 +150,11 @@ func (q *PSQLQueryAdapter) QueryTokenRevoke(ctx context.Context, id string) bob.
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryTokenDelete(ctx context.Context, id string) bob.Query {
+func (q *PSQLQuerier) QueryTokenDelete(ctx context.Context, id string) bob.Query {
 	return psql.Delete(dm.From(psql.Quote(models.TableToken)), dm.Where(psql.Quote("id").EQ(psql.Arg(id))))
 }
 
-func (q *PSQLQueryAdapter) QueryPasswordlessTokenInsert(ctx context.Context, token *models.PasswordlessToken) bob.Query {
+func (q *PSQLQuerier) QueryPasswordlessTokenInsert(ctx context.Context, token *models.PasswordlessToken) bob.Query {
 	return psql.Insert(
 		im.Into(psql.Quote(models.TablePasswordlessToken),
 			models.ColumnEmail,
@@ -172,14 +172,14 @@ func (q *PSQLQueryAdapter) QueryPasswordlessTokenInsert(ctx context.Context, tok
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryPasswordlessTokenGetByToken(ctx context.Context, token string) bob.Query {
+func (q *PSQLQuerier) QueryPasswordlessTokenGetByToken(ctx context.Context, token string) bob.Query {
 	return psql.Select(
 		sm.From(psql.Quote(models.TablePasswordlessToken)),
 		sm.Where(psql.Quote(models.ColumnToken).EQ(psql.Arg(token))),
 	)
 }
 
-func (q *PSQLQueryAdapter) QueryPasswordlessTokenDelete(ctx context.Context, token string) bob.Query {
+func (q *PSQLQuerier) QueryPasswordlessTokenDelete(ctx context.Context, token string) bob.Query {
 	return psql.Delete(
 		dm.From(psql.Quote(models.TablePasswordlessToken)),
 		dm.Where(psql.Quote(models.ColumnToken).EQ(psql.Arg(token))),

--- a/pkg/db/repository/postgres/query_test.go
+++ b/pkg/db/repository/postgres/query_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stephenafamo/bob"
 )
 
-func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
-	adapter := &PSQLQueryAdapter{}
+func TestPSQLQuerier_UserOperations(t *testing.T) {
+	querier := &PSQLQuerier{}
 	ctx := context.Background()
 	now := time.Now()
 
@@ -27,7 +27,7 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 	}
 
 	t.Run("Insert", func(t *testing.T) {
-		q := adapter.QueryUserInsert(ctx, user)
+		q := querier.QueryUserInsert(ctx, user)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -43,7 +43,7 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 	})
 
 	t.Run("GetByEmail", func(t *testing.T) {
-		q := adapter.QueryUserGetByEmail(ctx, user.Email)
+		q := querier.QueryUserGetByEmail(ctx, user.Email)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -61,7 +61,7 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 	})
 
 	t.Run("GetByID", func(t *testing.T) {
-		q := adapter.QueryUserGetByID(ctx, user.ID)
+		q := querier.QueryUserGetByID(ctx, user.ID)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -81,7 +81,7 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 			ID:       user.ID,
 			Provider: "google",
 		}
-		q := adapter.QueryUserUpdate(ctx, updateUser)
+		q := querier.QueryUserUpdate(ctx, updateUser)
 		sql, _, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -101,7 +101,7 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		q := adapter.QueryUserDelete(ctx, user.ID)
+		q := querier.QueryUserDelete(ctx, user.ID)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -116,8 +116,8 @@ func TestPSQLQueryAdapter_UserOperations(t *testing.T) {
 	})
 }
 
-func TestPSQLQueryAdapter_TokenOperations(t *testing.T) {
-	adapter := &PSQLQueryAdapter{}
+func TestPSQLQuerier_TokenOperations(t *testing.T) {
+	querier := &PSQLQuerier{}
 	ctx := context.Background()
 	now := time.Now()
 
@@ -132,7 +132,7 @@ func TestPSQLQueryAdapter_TokenOperations(t *testing.T) {
 	}
 
 	t.Run("Insert", func(t *testing.T) {
-		q := adapter.QueryTokenInsert(ctx, token)
+		q := querier.QueryTokenInsert(ctx, token)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -148,7 +148,7 @@ func TestPSQLQueryAdapter_TokenOperations(t *testing.T) {
 	})
 
 	t.Run("GetByID", func(t *testing.T) {
-		q := adapter.QueryTokenGetByID(ctx, token.ID)
+		q := querier.QueryTokenGetByID(ctx, token.ID)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -166,7 +166,7 @@ func TestPSQLQueryAdapter_TokenOperations(t *testing.T) {
 	})
 
 	t.Run("GetByToken", func(t *testing.T) {
-		q := adapter.QueryTokenGetByToken(ctx, token.Token)
+		q := querier.QueryTokenGetByToken(ctx, token.Token)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)
@@ -181,7 +181,7 @@ func TestPSQLQueryAdapter_TokenOperations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		q := adapter.QueryTokenDelete(ctx, token.ID)
+		q := querier.QueryTokenDelete(ctx, token.ID)
 		sql, args, err := bob.Build(ctx, q)
 		if err != nil {
 			t.Fatalf("failed to build query: %v", err)

--- a/pkg/db/repository/sqlite/query.go
+++ b/pkg/db/repository/sqlite/query.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stephenafamo/bob/dialect/sqlite/um"
 )
 
-type SqliteQueryAdapter struct {
+type SqliteQuerier struct {
 }
 
-func (q *SqliteQueryAdapter) QueryUserInsert(ctx context.Context, user *models.User) bob.Query {
+func (q *SqliteQuerier) QueryUserInsert(ctx context.Context, user *models.User) bob.Query {
 	return sqlite.Insert(
 		im.Into(models.TableUser,
 			models.ColumnEmail,
@@ -45,15 +45,15 @@ func (q *SqliteQueryAdapter) QueryUserInsert(ctx context.Context, user *models.U
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryUserGetByEmail(ctx context.Context, email string) bob.Query {
+func (q *SqliteQuerier) QueryUserGetByEmail(ctx context.Context, email string) bob.Query {
 	return sqlite.Select(sm.From(models.TableUser), sm.Where(sqlite.Quote(models.ColumnEmail).EQ(sqlite.Arg(email))))
 }
 
-func (q *SqliteQueryAdapter) QueryUserGetByID(ctx context.Context, id string) bob.Query {
+func (q *SqliteQuerier) QueryUserGetByID(ctx context.Context, id string) bob.Query {
 	return sqlite.Select(sm.From(models.TableUser), sm.Where(sqlite.Quote("id").EQ(sqlite.Arg(id))))
 }
 
-func (q *SqliteQueryAdapter) QueryUserGetByProvider(ctx context.Context, provider, providerID string) bob.Query {
+func (q *SqliteQuerier) QueryUserGetByProvider(ctx context.Context, provider, providerID string) bob.Query {
 	return sqlite.Select(
 		sm.From(models.TableUser),
 		sm.Where(
@@ -63,7 +63,7 @@ func (q *SqliteQueryAdapter) QueryUserGetByProvider(ctx context.Context, provide
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryUserUpdate(ctx context.Context, user *models.User) bob.Query {
+func (q *SqliteQuerier) QueryUserUpdate(ctx context.Context, user *models.User) bob.Query {
 	qm := []bob.Mod[*dialect.UpdateQuery]{
 		um.Table(models.TableUser),
 		um.SetCol(models.ColumnUpdatedAt).ToArg(time.Now().UTC()),
@@ -100,11 +100,11 @@ func (q *SqliteQueryAdapter) QueryUserUpdate(ctx context.Context, user *models.U
 	return sqlite.Update(qm...)
 }
 
-func (q *SqliteQueryAdapter) QueryUserDelete(ctx context.Context, id string) bob.Query {
+func (q *SqliteQuerier) QueryUserDelete(ctx context.Context, id string) bob.Query {
 	return sqlite.Delete(dm.From(models.TableUser), dm.Where(sqlite.Quote("id").EQ(sqlite.Arg(id))))
 }
 
-func (q *SqliteQueryAdapter) QueryTokenInsert(ctx context.Context, token *models.Token) bob.Query {
+func (q *SqliteQuerier) QueryTokenInsert(ctx context.Context, token *models.Token) bob.Query {
 	return sqlite.Insert(
 		im.Into(models.TableToken,
 			models.ColumnUserID,
@@ -128,15 +128,15 @@ func (q *SqliteQueryAdapter) QueryTokenInsert(ctx context.Context, token *models
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryTokenGetByID(ctx context.Context, id string) bob.Query {
+func (q *SqliteQuerier) QueryTokenGetByID(ctx context.Context, id string) bob.Query {
 	return sqlite.Select(sm.From(models.TableToken), sm.Where(sqlite.Quote("id").EQ(sqlite.Arg(id))))
 }
 
-func (q *SqliteQueryAdapter) QueryTokenGetByToken(ctx context.Context, token string) bob.Query {
+func (q *SqliteQuerier) QueryTokenGetByToken(ctx context.Context, token string) bob.Query {
 	return sqlite.Select(sm.From(models.TableToken), sm.Where(sqlite.Quote(models.ColumnToken).EQ(sqlite.Arg(token))))
 }
 
-func (q *SqliteQueryAdapter) QueryTokenRevoke(ctx context.Context, id string) bob.Query {
+func (q *SqliteQuerier) QueryTokenRevoke(ctx context.Context, id string) bob.Query {
 	return sqlite.Update(
 		um.Table(models.TableToken),
 		um.SetCol(models.ColumnRevoked).ToArg(true),
@@ -144,11 +144,11 @@ func (q *SqliteQueryAdapter) QueryTokenRevoke(ctx context.Context, id string) bo
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryTokenDelete(ctx context.Context, id string) bob.Query {
+func (q *SqliteQuerier) QueryTokenDelete(ctx context.Context, id string) bob.Query {
 	return sqlite.Delete(dm.From(models.TableToken), dm.Where(sqlite.Quote("id").EQ(sqlite.Arg(id))))
 }
 
-func (q *SqliteQueryAdapter) QueryPasswordlessTokenInsert(ctx context.Context, token *models.PasswordlessToken) bob.Query {
+func (q *SqliteQuerier) QueryPasswordlessTokenInsert(ctx context.Context, token *models.PasswordlessToken) bob.Query {
 	return sqlite.Insert(
 		im.Into(models.TablePasswordlessToken,
 			models.ColumnEmail,
@@ -166,14 +166,14 @@ func (q *SqliteQueryAdapter) QueryPasswordlessTokenInsert(ctx context.Context, t
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryPasswordlessTokenGetByToken(ctx context.Context, token string) bob.Query {
+func (q *SqliteQuerier) QueryPasswordlessTokenGetByToken(ctx context.Context, token string) bob.Query {
 	return sqlite.Select(
 		sm.From(models.TablePasswordlessToken),
 		sm.Where(sqlite.Quote(models.ColumnToken).EQ(sqlite.Arg(token))),
 	)
 }
 
-func (q *SqliteQueryAdapter) QueryPasswordlessTokenDelete(ctx context.Context, token string) bob.Query {
+func (q *SqliteQuerier) QueryPasswordlessTokenDelete(ctx context.Context, token string) bob.Query {
 	return sqlite.Delete(
 		dm.From(models.TablePasswordlessToken),
 		dm.Where(sqlite.Quote(models.ColumnToken).EQ(sqlite.Arg(token))),

--- a/pkg/handler/errors.go
+++ b/pkg/handler/errors.go
@@ -1,0 +1,24 @@
+package handler
+
+import "errors"
+
+var (
+	ErrInvalidRequestBody         = errors.New("invalid request body")
+	ErrRefreshTokenRequired      = errors.New("refresh_token is required")
+	ErrTokenRequired             = errors.New("token is required")
+	ErrUserNotFoundInContext      = errors.New("could not retrieve user from context")
+	ErrInvalidToken              = errors.New("invalid token")
+	ErrInvalidTokenClaims        = errors.New("invalid token claims")
+	ErrBearerTokenRequired       = errors.New("bearer token required")
+	ErrAuthorizationHeaderRequired = errors.New("authorization header required")
+	ErrCouldNotCreateToken       = errors.New("could not create token")
+	ErrCouldNotCreateUser        = errors.New("could not create user")
+	ErrInvalidCredentials        = errors.New("invalid email or password")
+	ErrCouldNotRetrieveUser      = errors.New("could not retrieve user")
+	ErrCouldNotRevokeToken       = errors.New("could not revoke token")
+	ErrCouldNotDeleteUser        = errors.New("could not delete user")
+	ErrCouldNotProcessPasswordReset = errors.New("could not process password reset request")
+	ErrCouldNotProcessPasswordless = errors.New("could not process passwordless request")
+	ErrUserIDNotFoundInContext   = errors.New("user id not found in context")
+	ErrUnexpectedSigningMethod   = errors.New("unexpected signing method")
+)

--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 
@@ -13,37 +12,37 @@ func (h *Handler) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
-			WriteJSONResponseError(w, http.StatusUnauthorized, errors.New("authorization header required"))
+			WriteJSONResponseError(w, http.StatusUnauthorized, ErrAuthorizationHeaderRequired)
 			return
 		}
 
 		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 		if tokenString == authHeader {
-			WriteJSONResponseError(w, http.StatusUnauthorized, errors.New("bearer token required"))
+			WriteJSONResponseError(w, http.StatusUnauthorized, ErrBearerTokenRequired)
 			return
 		}
 
 		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, errors.New("unexpected signing method")
+				return nil, ErrUnexpectedSigningMethod
 			}
 			return []byte(h.svc.Cfg.JWTSecret), nil
 		})
 
 		if err != nil {
-			WriteJSONResponseError(w, http.StatusUnauthorized, errors.New("invalid token"))
+			WriteJSONResponseError(w, http.StatusUnauthorized, ErrInvalidToken)
 			return
 		}
 
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok || !token.Valid {
-			WriteJSONResponseError(w, http.StatusUnauthorized, errors.New("invalid token"))
+			WriteJSONResponseError(w, http.StatusUnauthorized, ErrInvalidToken)
 			return
 		}
 
 		userID, ok := claims["sub"].(string)
 		if !ok {
-			WriteJSONResponseError(w, http.StatusUnauthorized, errors.New("invalid token claims"))
+			WriteJSONResponseError(w, http.StatusUnauthorized, ErrInvalidTokenClaims)
 			return
 		}
 		ctx := context.WithValue(r.Context(), userContextKey, userID)


### PR DESCRIPTION
This change refactors the codebase to centralize error definitions and improve naming conventions in the repository layer. 

Key changes:
1. Created `pkg/handler/errors.go` to hold common error variables, replacing repetitive `errors.New` calls in the handler and middleware.
2. Renamed the repository "adapter" components to "querier" (e.g., `IQueryAdapter` -> `Querier`, `PSQLQueryAdapter` -> `PSQLQuerier`). This is a more descriptive name for components responsible for building database queries.
3. Renamed `adapter.go` and `adapter_test.go` to `query.go` and `query_test.go` respectively.
4. Updated `example.env` with missing configuration variables identified during the process (`EZAUTH_BASE_URL`, `EZAUTH_SECRET`, and SMTP settings).
5. Cleaned up unused `errors` imports in the handler package.
6. Verified all changes by running the full test suite.

---
*PR created automatically by Jules for task [10762358005102604728](https://jules.google.com/task/10762358005102604728) started by @josuebrunel*