### PR TITLE
Add comprehensive documentation for GitHub Pages

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,0 +1,167 @@
+# API Endpoints
+
+All `ezauth` responses follow a consistent format:
+
+```json
+{
+  "error": "Error message if any, else null",
+  "data": "The actual response data"
+}
+```
+
+## Public Endpoints
+
+### Register
+`POST /auth/register`
+
+Creates a new user and returns authentication tokens.
+
+**Request Body:**
+```json
+{
+  "email": "user@example.com",
+  "password": "yourpassword",
+  "first_name": "John",
+  "last_name": "Doe",
+  "locale": "en-US",
+  "timezone": "UTC",
+  "roles": "user,admin",
+  "data": {
+    "key": "value"
+  }
+}
+```
+
+**Response Data:**
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_in": 3600,
+  "token_type": "Bearer"
+}
+```
+
+### Login
+`POST /auth/login`
+
+Authenticates a user and returns tokens.
+
+**Request Body:**
+```json
+{
+  "email": "user@example.com",
+  "password": "yourpassword"
+}
+```
+
+**Response Data:** Same as Register.
+
+### Refresh Token
+`POST /auth/token/refresh`
+
+Exchange a refresh token for a new set of tokens (access and refresh).
+
+**Request Body:**
+```json
+{
+  "refresh_token": "..."
+}
+```
+
+**Response Data:** Same as Register.
+
+### Password Reset Request
+`POST /auth/password-reset/request`
+
+Sends a password reset link to the user's email.
+
+**Request Body:**
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+### Password Reset Confirm
+`POST /auth/password-reset/confirm`
+
+Resets the user's password using a token received via email.
+
+**Request Body:**
+```json
+{
+  "token": "...",
+  "password": "newpassword"
+}
+```
+
+### Passwordless Request (Magic Link)
+`POST /auth/passwordless/request`
+
+Sends a magic login link to the user's email.
+
+**Request Body:**
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+### Passwordless Login
+`GET /auth/passwordless/login?token=...`
+
+Authenticates a user using a magic link token.
+
+**Response Data:** Same as Register.
+
+### OAuth2 Login
+`GET /auth/oauth2/{provider}/login`
+
+Redirects the user to the OAuth2 provider (google, github, facebook).
+
+### OAuth2 Callback
+`GET /auth/oauth2/{provider}/callback`
+
+The callback URL handled by `ezauth`. After success, it redirects to the `EZAUTH_OAUTH2_CALLBACK_URL` with the tokens as query parameters.
+
+## Protected Endpoints
+
+These endpoints require an `Authorization: Bearer <access_token>` header.
+
+### User Info
+`GET /auth/userinfo`
+
+Returns the profile information for the currently authenticated user.
+
+**Response Data:**
+```json
+{
+  "id": "...",
+  "email": "user@example.com",
+  "provider": "local",
+  "email_verified": true,
+  "first_name": "John",
+  "last_name": "Doe",
+  "roles": "user,admin",
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+### Logout
+`POST /auth/logout`
+
+Revokes the provided refresh token.
+
+**Request Body:**
+```json
+{
+  "refresh_token": "..."
+}
+```
+
+### Delete User
+`DELETE /auth/user`
+
+Deletes the currently authenticated user's account.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,50 @@
+# Architecture
+
+`ezauth` is built with a modular architecture that separates concerns between configuration, data persistence, business logic, and the HTTP layer.
+
+## Component Overview
+
+### `EzAuth` (The Library Entry Point)
+The `EzAuth` struct (defined in `ezauth.go`) is the primary way to interact with the library. It orchestrates the other components and provides a simplified API for common tasks.
+
+```go
+type EzAuth struct {
+    Config  *config.Config
+    Repo    *repository.Repository
+    Service *service.Auth
+    Handler *handler.Handler
+}
+```
+
+### `Service` (Business Logic)
+The `service` package (located in `pkg/service/`) contains the core authentication logic. It is independent of the HTTP layer. This is where you'll find logic for:
+- User authentication and hashing.
+- Token generation and validation (JWT and Refresh Tokens).
+- Password reset and passwordless flows.
+- Interaction with the Mailer.
+
+### `Handler` (HTTP Layer)
+The `handler` package (located in `pkg/handler/`) defines the RESTful API. It uses the `service` package to perform actions. It is responsible for:
+- Routing requests (using `chi`).
+- Parsing and validating request bodies.
+- Enforcing authentication via middleware.
+- Formatting JSON responses.
+
+### `Repository` (Data Persistence)
+The `repository` package (located in `pkg/db/repository/`) handles all database interactions. It uses `bob` as a query builder and supports multiple database dialects.
+
+### `Config` (Configuration)
+The `config` package (located in `pkg/config/`) handles loading configuration from environment variables.
+
+## Data Flow
+
+1.  **Incoming Request**: An HTTP request arrives at the `Handler`.
+2.  **Routing & Middleware**: The `Handler` routes the request to the appropriate function. If the route is protected, the `AuthMiddleware` validates the JWT.
+3.  **Service Call**: The `Handler` parses the request body and calls a method on the `Service`.
+4.  **Database Interaction**: The `Service` performs business logic and interacts with the `Repository` to read or write data.
+5.  **Response**: The `Service` returns a result to the `Handler`, which then sends a JSON response back to the client.
+
+## Extension Points
+
+- **Mailer**: You can provide your own implementation of the `Mailer` interface if you need to use a service other than SMTP (e.g., SendGrid, Mailgun).
+- **Custom Router**: You can pass your own `chi.Router` to the `Handler` if you want to add global middlewares or customize the routing behavior.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,64 @@
+# Configuration
+
+`ezauth` is configured primarily through environment variables. All variables are prefixed with `EZAUTH_`.
+
+## Global Settings
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `EZAUTH_ADDR` | The address the server listens on. | `:8080` |
+| `EZAUTH_BASE_URL` | The base URL of the auth service (used for emails). | `http://localhost:8080` |
+| `EZAUTH_DEBUG` | Enable debug logging. | `false` |
+| `EZAUTH_SECRET` | Secret key used for various internal encryptions. | |
+| `EZAUTH_JWT_SECRET` | Secret key used to sign JWT tokens. | |
+| `EZAUTH_TIMEOUT` | Request timeout duration. | `30s` |
+
+## Database Settings
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `EZAUTH_DB_DIALECT` | Database dialect (`sqlite3` or `postgres`). | `sqlite3` |
+| `EZAUTH_DB_DSN` | Database connection string. | `ezauth.db` |
+
+## SMTP Settings
+
+Used for sending password reset and magic link emails.
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `EZAUTH_SMTP_HOST` | SMTP server host. | |
+| `EZAUTH_SMTP_PORT` | SMTP server port. | `587` |
+| `EZAUTH_SMTP_USER` | SMTP username. | |
+| `EZAUTH_SMTP_PASSWORD` | SMTP password. | |
+| `EZAUTH_SMTP_FROM` | The email address to send from. | `noreply@example.com` |
+
+## OAuth2 Settings
+
+### General
+| Variable | Description |
+| -------- | ----------- |
+| `EZAUTH_OAUTH2_CALLBACK_URL` | The URL users are redirected to after successful OAuth2 login. |
+
+### Google
+| Variable | Description |
+| -------- | ----------- |
+| `EZAUTH_OAUTH2_GOOGLE_CLIENT_ID` | Google OAuth2 Client ID. |
+| `EZAUTH_OAUTH2_GOOGLE_CLIENT_SECRET` | Google OAuth2 Client Secret. |
+| `EZAUTH_OAUTH2_GOOGLE_REDIRECT_URL` | Redirect URL registered in Google Console. |
+| `EZAUTH_OAUTH2_GOOGLE_SCOPES` | Scopes to request (e.g., `email,profile`). |
+
+### GitHub
+| Variable | Description |
+| -------- | ----------- |
+| `EZAUTH_OAUTH2_GITHUB_CLIENT_ID` | GitHub OAuth2 Client ID. |
+| `EZAUTH_OAUTH2_GITHUB_CLIENT_SECRET` | GitHub OAuth2 Client Secret. |
+| `EZAUTH_OAUTH2_GITHUB_REDIRECT_URL` | Redirect URL registered in GitHub settings. |
+| `EZAUTH_OAUTH2_GITHUB_SCOPES` | Scopes to request (e.g., `user:email`). |
+
+### Facebook
+| Variable | Description |
+| -------- | ----------- |
+| `EZAUTH_OAUTH2_FACEBOOK_CLIENT_ID` | Facebook OAuth2 Client ID. |
+| `EZAUTH_OAUTH2_FACEBOOK_CLIENT_SECRET` | Facebook OAuth2 Client Secret. |
+| `EZAUTH_OAUTH2_FACEBOOK_REDIRECT_URL` | Redirect URL registered in Facebook settings. |
+| `EZAUTH_OAUTH2_FACEBOOK_SCOPES` | Scopes to request (e.g., `email`). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# ezauth
+
+`ezauth` is a simple and easy-to-use authentication library and service for Golang. It provides a robust set of features to handle user registration, login, session management, and more.
+
+## Features
+
+- **Email/Password Authentication**: Secure user registration and login.
+- **JWT-based Sessions**: Access and Refresh tokens with rotation for enhanced security.
+- **OAuth2 Support**: Built-in support for Google, GitHub, and Facebook.
+- **Password Reset & Passwordless**: Magic link and password reset flows.
+- **Extended User Profiles**: Store additional user information like name, locale, timezone, and roles.
+- **Multi-Database Support**: Support for SQLite and PostgreSQL.
+- **Flexible Integration**: Use it as a standalone service or embed it as a library.
+
+## Getting Started
+
+`ezauth` can be used in two primary ways:
+
+1.  **[Standalone Service](./standalone.md)**: Run `ezauth` as an independent authentication service.
+2.  **[Library](./library.md)**: Embed `ezauth` directly into your Go application.
+
+## Documentation Sections
+
+- **[Installation](./installation.md)**: How to get `ezauth`.
+- **[Configuration](./configuration.md)**: Details on all environment variables.
+- **[API Endpoints](./api-endpoints.md)**: Comprehensive API reference.
+- **[Architecture](./architecture.md)**: Understanding `EzAuth`, `Handler`, and `Service`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,27 @@
+# Installation
+
+Depending on how you intend to use `ezauth`, there are different ways to install it.
+
+## As a Library
+
+To use `ezauth` as a library in your Go project, you can use `go get`:
+
+```bash
+go get github.com/josuebrunel/ezauth
+```
+
+## As a Standalone Service
+
+If you want to run `ezauth` as a service, you can clone the repository and build the binary:
+
+```bash
+git clone https://github.com/josuebrunel/ezauth.git
+cd ezauth
+go build -o ezauthapi ./cmd/ezauthapi
+```
+
+Alternatively, you can run it using Docker:
+
+```bash
+docker-compose up -d
+```

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,0 +1,105 @@
+# Using ezauth as a Library
+
+Embedding `ezauth` directly into your Go application provides the most seamless integration. It allows you to use `ezauth`'s middleware and internal services directly within your code.
+
+## Basic Integration
+
+Here is a complete example of how to integrate `ezauth` into a `chi` router:
+
+```go
+package main
+
+import (
+    "net/http"
+    "github.com/go-chi/chi/v5"
+    "github.com/josuebrunel/ezauth"
+    "github.com/josuebrunel/ezauth/pkg/config"
+)
+
+func main() {
+    // 1. Setup Config
+    // LoadConfig reads from environment variables with the EZAUTH_ prefix.
+    cfg, err := config.LoadConfig()
+    if err != nil {
+        panic(err)
+    }
+
+    // 2. Initialize EzAuth
+    // "auth" is the path prefix where the routes will be mounted.
+    auth, err := ezauth.New(&cfg, "auth")
+    if err != nil {
+        panic(err)
+    }
+
+    // 3. Run migrations
+    // Ensure the database schema is up to date.
+    if err := auth.Migrate(); err != nil {
+        panic(err)
+    }
+
+    r := chi.NewRouter()
+
+    // 4. Mount Auth Routes
+    // This exposes /auth/register, /auth/login, etc.
+    // auth.Handler implements http.Handler.
+    r.Mount("/auth", auth.Handler)
+
+    // 5. Protect your own routes
+    r.Group(func(r chi.Router) {
+        r.Use(auth.AuthMiddleware)
+
+        r.Get("/protected", func(w http.ResponseWriter, r *http.Request) {
+            // Retrieve the userID from the context
+            userID, _ := auth.GetUserID(r.Context())
+            w.Write([]byte("Hello user: " + userID))
+        })
+    })
+
+    http.ListenAndServe(":3000", r)
+}
+```
+
+## Core Components
+
+When you initialize `ezauth`, you get access to several key components through the `EzAuth` struct:
+
+### `EzAuth` Struct
+
+The `EzAuth` struct is the main entry point. It contains:
+- `Config`: The loaded configuration.
+- `Repo`: The database repository.
+- `Service`: The core authentication logic.
+- `Handler`: The HTTP handler.
+
+### The Handler
+
+The `Handler` (accessible via `auth.Handler`) handles all HTTP routing and request processing. It is built on top of `chi`, but it implements the `http.Handler` interface, so it can be used with any Go HTTP framework.
+
+Key methods:
+- `ServeHTTP(w, r)`: Standard HTTP handler method.
+- `AuthMiddleware(next)`: Middleware to protect routes. It validates the JWT in the `Authorization` header and puts the `userID` in the request context.
+
+### The Service
+
+The `Service` (accessible via `auth.Service`) contains the business logic for authentication. You can use it directly if you want to perform actions programmatically without going through HTTP.
+
+Example of using the service directly:
+
+```go
+// Create a user manually
+user, err := auth.Service.UserCreate(ctx, &service.RequestBasicAuth{
+    Email: "user@example.com",
+    Password: "securepassword",
+})
+
+// Generate tokens for a user
+tokens, err := auth.Service.TokenCreate(ctx, user)
+```
+
+## Using an Existing Database Connection
+
+If your application already has a `*sql.DB` connection, you can use `NewWithDB`:
+
+```go
+auth, err := ezauth.NewWithDB(&cfg, myDBConnection, "auth")
+```

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,0 +1,50 @@
+# Standalone Service
+
+Running `ezauth` as a standalone service allows you to offload authentication logic from your main application. It exposes a RESTful API that your frontend or other microservices can interact with.
+
+## Building and Running
+
+1.  **Clone the Repository**:
+    ```bash
+    git clone https://github.com/josuebrunel/ezauth.git
+    cd ezauth
+    ```
+
+2.  **Configure**:
+    Create a `.env` file or set environment variables. See [Configuration](./configuration.md) for all available options.
+    ```bash
+    cp example.env .env
+    # Edit .env with your settings
+    ```
+
+3.  **Build**:
+    ```bash
+    go build -o ezauthapi ./cmd/ezauthapi
+    ```
+
+4.  **Run Migrations**:
+    `ezauth` can automatically run migrations on startup when used as a library, but for the standalone service, you can run them manually or ensure they are run by the binary.
+    ```bash
+    go build -o migrate ./cmd/migrate
+    ./migrate up
+    ```
+
+5.  **Start the Service**:
+    ```bash
+    ./ezauthapi
+    ```
+
+## Using Docker
+
+You can also use the provided `docker-compose.yaml` to run `ezauth` along with a PostgreSQL database.
+
+```bash
+docker-compose up -d
+```
+
+## Integrating with your Application
+
+Once `ezauth` is running, your application can:
+1.  **Direct Users to Login/Register**: Your frontend can send `POST` requests to `ezauth`'s `/auth/login` or `/auth/register` endpoints.
+2.  **Secure Your Routes**: Your main application should verify the JWT access tokens issued by `ezauth`. Since `ezauth` uses standard JWTs, you can use any JWT library to verify the signature (using `EZAUTH_JWT_SECRET`).
+3.  **Retrieve User Info**: Send a `GET` request to `/auth/userinfo` with the `Authorization: Bearer <access_token>` header.


### PR DESCRIPTION
This PR adds a `docs/` folder containing comprehensive documentation for `ezauth`. It covers both standalone and library usage patterns, provides a detailed API reference, documents all environment variables, and explains the internal architecture (EzAuth, Handler, Service). This documentation is intended for use with GitHub Pages.

---
*PR created automatically by Jules for task [1302477025175485087](https://jules.google.com/task/1302477025175485087) started by @josuebrunel*