### PR TITLE
Add lightweight hook system for auth events

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,13 @@ func main() {
     // 4. Add session middleware (handles sessions and user loading)
     r.Use(auth.SessionMiddleware)
 
-    // 5. Mount Auth Routes
+    // 5. Hooks (Optional - react to auth events)
+    auth.Hooks.OnUserCreated = func(ctx context.Context, user *ezauth.User) error {
+        fmt.Printf("Welcome email sent to %s\n", user.Email)
+        return nil
+    }
+
+    // 6. Mount Auth Routes
     r.Mount("/auth", auth.Handler)
 
     // Protected Route Example
@@ -335,6 +341,41 @@ These endpoints accept `application/json` and return JSON responses.
 | GET    | `/auth/api/userinfo`               | Get current user info (Protected) |
 | POST   | `/auth/api/logout`                 | Revoke refresh token (Protected)  |
 | DELETE | `/auth/api/user`                   | Delete account (Protected)        |
+
+## Hooks
+
+`ezauth` includes a lightweight hook system that allows you to plug in custom logic at key points in the authentication lifecycle (e.g., sending a welcome email, auditing sign-ins, or syncing users to external services).
+
+Hooks are available on the `EzAuth.Hooks` struct as function fields. All hooks are `nil` by default and are called synchronously.
+
+```go
+auth.Hooks.OnUserCreated = func(ctx context.Context, user *ezauth.User) error {
+    // Send welcome email, setup profile, etc.
+    return nil
+}
+
+auth.Hooks.OnOAuth2SignedIn = func(ctx context.Context, user *ezauth.User, provider string) error {
+    log.Printf("User %s signed in via %s", user.Email, provider)
+    return nil
+}
+```
+
+### Supported Hooks
+
+| Hook                       | Description                                         |
+| -------------------------- | --------------------------------------------------- |
+| `OnUserCreated`            | Called when a new user is registered (Email or API) |
+| `OnUserUpdated`            | Called when user info or password is changed        |
+| `OnUserDeleted`            | Called when a user account is deleted               |
+| `OnUserSignedIn`           | Called after a successful login (Email/Password)    |
+| `OnUserSignedOut`          | Called after a successful logout                    |
+| `OnUserTokenRefreshed`     | Called after a successful token refresh             |
+| `OnPasswordResetRequested` | Called when a password reset link is sent           |
+| `OnPasswordResetConfirmed` | Called after a successful password reset            |
+| `OnPasswordlessRequested`  | Called when a magic link is sent                    |
+| `OnPasswordlessSignedIn`   | Called after a successful magic link login          |
+| `OnOAuth2SignedIn`         | Called after any successful OAuth2 login            |
+| `OnOAuth2Created`          | Called when a new user is created via OAuth2        |
 
 ## Middlewares
  

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -50,7 +50,13 @@ func main() {
     // 4. Add session middleware (handles sessions and user loading)
     r.Use(auth.SessionMiddleware)
 
-    // 5. Mount Auth Routes
+    // 5. Hooks (Optional - react to auth events)
+    auth.Hooks.OnUserCreated = func(ctx context.Context, user *ezauth.User) error {
+        fmt.Printf("Welcome email sent to %s\n", user.Email)
+        return nil
+    }
+
+    // 6. Mount Auth Routes
     r.Mount("/auth", auth.Handler)
 
     // Public Route (Login)
@@ -245,6 +251,41 @@ r.Get("/my-custom-login", func(w http.ResponseWriter, r *http.Request) {
  })
  ```
  
+## Hooks
+
+`ezauth` includes a lightweight hook system that allows you to plug in custom logic at key points in the authentication lifecycle (e.g., sending a welcome email, auditing sign-ins, or syncing users to external services).
+
+Hooks are available on the `EzAuth.Hooks` struct as function fields. All hooks are `nil` by default and are called synchronously.
+
+```go
+auth.Hooks.OnUserCreated = func(ctx context.Context, user *ezauth.User) error {
+    // Send welcome email, setup profile, etc.
+    return nil
+}
+
+auth.Hooks.OnOAuth2SignedIn = func(ctx context.Context, user *ezauth.User, provider string) error {
+    log.Printf("User %s signed in via %s", user.Email, provider)
+    return nil
+}
+```
+
+### Supported Hooks
+
+| Hook                       | Description                                         |
+| -------------------------- | --------------------------------------------------- |
+| `OnUserCreated`            | Called when a new user is registered (Email or API) |
+| `OnUserUpdated`            | Called when user info or password is changed        |
+| `OnUserDeleted`            | Called when a user account is deleted               |
+| `OnUserSignedIn`           | Called after a successful login (Email/Password)    |
+| `OnUserSignedOut`          | Called after a successful logout                    |
+| `OnUserTokenRefreshed`     | Called after a successful token refresh             |
+| `OnPasswordResetRequested` | Called when a password reset link is sent           |
+| `OnPasswordResetConfirmed` | Called after a successful password reset            |
+| `OnPasswordlessRequested`  | Called when a magic link is sent                    |
+| `OnPasswordlessSignedIn`   | Called after a successful magic link login          |
+| `OnOAuth2SignedIn`         | Called after any successful OAuth2 login            |
+| `OnOAuth2Created`          | Called when a new user is created via OAuth2        |
+
  ## Core Components
 
 When you initialize `ezauth`, you get access to several key components through the `EzAuth` struct:
@@ -256,6 +297,7 @@ The `EzAuth` struct is the main entry point. It contains:
 - `Repo`: The database repository.
 - `Service`: The core authentication logic.
 - `Handler`: The HTTP handler.
+- `Hooks`: The hook system.
 
 ### The Handler
 

--- a/ezauth.go
+++ b/ezauth.go
@@ -19,6 +19,9 @@ import (
 	"github.com/josuebrunel/gopkg/xlog"
 )
 
+// User represents a user in the system.
+type User = models.User
+
 // EzAuth represents the main entry point for the ezauth library.
 // It encapsulates configuration, repository, service, and handler components.
 type EzAuth struct {
@@ -26,6 +29,7 @@ type EzAuth struct {
 	Repo    *repository.Repository
 	Service *service.Auth
 	Handler *handler.Handler
+	Hooks   *service.Hooks
 }
 
 // New creates a new EzAuth instance from a config.
@@ -54,6 +58,7 @@ func New(cfg *config.Config, path string) (*EzAuth, error) {
 		Repo:    repo,
 		Service: svc,
 		Handler: h,
+		Hooks:   svc.Hooks,
 	}, nil
 }
 
@@ -69,6 +74,7 @@ func NewWithDB(cfg *config.Config, db *sql.DB, path string) (*EzAuth, error) {
 		Repo:    repo,
 		Service: svc,
 		Handler: h,
+		Hooks:   svc.Hooks,
 	}, nil
 }
 

--- a/pkg/handler/api.go
+++ b/pkg/handler/api.go
@@ -89,6 +89,8 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	_ = service.CallHook(h.svc.Hooks.OnUserSignedIn, r.Context(), user)
+
 	tokenResp, err := h.svc.TokenCreate(r.Context(), user)
 	if err != nil {
 		WriteJSONResponseError(w, http.StatusInternalServerError, ErrCouldNotCreateToken)
@@ -181,6 +183,12 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	if req.RefreshToken == "" {
 		WriteJSONResponseError(w, http.StatusBadRequest, ErrRefreshTokenRequired)
 		return
+	}
+
+	if userID, err := GetUserID(r.Context()); err == nil {
+		if user, err := h.svc.Repo.UserGetByID(r.Context(), userID); err == nil {
+			_ = service.CallHook(h.svc.Hooks.OnUserSignedOut, r.Context(), user)
+		}
 	}
 
 	if err := h.svc.TokenRevoke(r.Context(), req.RefreshToken); err != nil {

--- a/pkg/handler/form.go
+++ b/pkg/handler/form.go
@@ -77,6 +77,8 @@ func (h *Handler) FormLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	_ = service.CallHook(h.svc.Hooks.OnUserSignedIn, r.Context(), user)
+
 	tokenResp, err := h.svc.TokenCreate(r.Context(), user)
 	if err != nil {
 		h.redirectWithError(w, r, h.svc.Cfg.Pages.Login, ErrCouldNotCreateToken.Error())
@@ -91,6 +93,12 @@ func (h *Handler) FormLogin(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) FormLogout(w http.ResponseWriter, r *http.Request) {
 
 	if tokens, ok := h.GetSessionTokens(r.Context()); ok {
+		if userID, err := GetUserID(r.Context()); err == nil {
+			if user, err := h.svc.Repo.UserGetByID(r.Context(), userID); err == nil {
+				_ = service.CallHook(h.svc.Hooks.OnUserSignedOut, r.Context(), user)
+			}
+		}
+
 		if refreshToken, ok := tokens["refresh_token"]; ok && refreshToken != "" {
 			_ = h.svc.TokenRevoke(r.Context(), refreshToken)
 		}
@@ -279,7 +287,7 @@ func (h *Handler) OAuth2Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.svc.OAuth2Authenticate(r.Context(), provider, userInfo)
+	user, _, err := h.svc.OAuth2Authenticate(r.Context(), provider, userInfo)
 	if err != nil {
 		WriteJSONResponseError(w, http.StatusInternalServerError, fmt.Errorf("failed to authenticate user: %w", err))
 		return

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -78,6 +78,7 @@ func (a *Auth) UserCreate(ctx context.Context, req *RequestBasicAuth) (*models.U
 		return nil, err
 	}
 	xlog.Info("user created", "id", u.ID, "email", u.Email)
+	_ = CallHook(a.Hooks.OnUserCreated, ctx, u)
 	return u, nil
 }
 
@@ -121,16 +122,28 @@ func (a Auth) UserUpdatePassword(ctx context.Context, user *models.User, passwor
 		return nil, err
 	}
 	user.PasswordHash = hash
-	return a.Repo.UserUpdate(ctx, user)
+	u, err := a.Repo.UserUpdate(ctx, user)
+	if err == nil {
+		_ = CallHook(a.Hooks.OnUserUpdated, ctx, u)
+	}
+	return u, err
 }
 
 // UserUpdate updates the user information.
 func (a Auth) UserUpdate(ctx context.Context, user *models.User) (*models.User, error) {
-	return a.Repo.UserUpdate(ctx, user)
+	u, err := a.Repo.UserUpdate(ctx, user)
+	if err == nil {
+		_ = CallHook(a.Hooks.OnUserUpdated, ctx, u)
+	}
+	return u, err
 }
 
 // UserDelete deletes a user by ID.
 func (a Auth) UserDelete(ctx context.Context, id string) error {
+	user, err := a.Repo.UserGetByID(ctx, id)
+	if err == nil {
+		_ = CallHook(a.Hooks.OnUserDeleted, ctx, user)
+	}
 	return a.Repo.UserDelete(ctx, id)
 }
 
@@ -179,7 +192,12 @@ func (a *Auth) PasswordResetRequest(ctx context.Context, req RequestPasswordRese
 	subject := RenderTemplate(a.Cfg.EmailTemplates.PasswordResetSubject, data)
 	body := RenderTemplate(a.Cfg.EmailTemplates.PasswordResetBody, data)
 
-	return a.Mailer.Send(user.Email, subject, body)
+	if err := a.Mailer.Send(user.Email, subject, body); err != nil {
+		return err
+	}
+
+	_ = CallHook(a.Hooks.OnPasswordResetRequested, ctx, user)
+	return nil
 }
 
 // PasswordResetConfirm completes the password reset flow.
@@ -210,7 +228,12 @@ func (a *Auth) PasswordResetConfirm(ctx context.Context, req RequestPasswordRese
 		return err
 	}
 
-	return a.Repo.TokenRevoke(ctx, token.ID)
+	if err := a.Repo.TokenRevoke(ctx, token.ID); err != nil {
+		return err
+	}
+
+	_ = CallHook(a.Hooks.OnPasswordResetConfirmed, ctx, user)
+	return nil
 }
 
 // RequestPasswordless defines the parameters for requesting a magic link.
@@ -285,6 +308,8 @@ func (a *Auth) PasswordlessRequest(ctx context.Context, req RequestPasswordless)
 		return err
 	}
 	xlog.Info("passwordless login email sent", "email", req.Email)
+
+	_ = CallHook(a.Hooks.OnPasswordlessRequested, ctx, user)
 	return nil
 }
 
@@ -334,6 +359,8 @@ func (a *Auth) PasswordlessLogin(ctx context.Context, tokenValue string) (*Token
 		return nil, err
 	}
 	xlog.Info("passwordless login successful", "user_id", user.ID)
+
+	_ = CallHook(a.Hooks.OnPasswordlessSignedIn, ctx, user)
 	return resp, nil
 }
 
@@ -444,7 +471,8 @@ func (a *Auth) OAuth2GetUserInfo(ctx context.Context, provider string, token *oa
 
 // OAuth2Authenticate authenticates a user using OAuth2 information.
 // It links the OAuth2 account to an existing user or creates a new one.
-func (a *Auth) OAuth2Authenticate(ctx context.Context, provider string, userInfo *OAuth2UserInfo) (*models.User, error) {
+// It returns the user and a boolean indicating if the user was newly created.
+func (a *Auth) OAuth2Authenticate(ctx context.Context, provider string, userInfo *OAuth2UserInfo) (*models.User, bool, error) {
 	xlog.Debug("authenticating via oauth2", "provider", provider, "email", userInfo.Email, "provider_id", userInfo.ID)
 
 	user, err := a.Repo.UserGetByProvider(ctx, provider, userInfo.ID)
@@ -455,13 +483,15 @@ func (a *Auth) OAuth2Authenticate(ctx context.Context, provider string, userInfo
 			u, err := a.Repo.UserUpdate(ctx, user)
 			if err != nil {
 				xlog.Error("failed to update user email from provider", "user_id", user.ID, "err", err)
-				return nil, err
+				return nil, false, err
 			}
 			xlog.Info("user authenticated via oauth2", "user_id", user.ID, "provider", provider)
-			return u, nil
+			_ = CallHookWithProvider(a.Hooks.OnOAuth2SignedIn, ctx, u, provider)
+			return u, false, nil
 		}
 		xlog.Info("user authenticated via oauth2", "user_id", user.ID, "provider", provider)
-		return user, nil
+		_ = CallHookWithProvider(a.Hooks.OnOAuth2SignedIn, ctx, user, provider)
+		return user, false, nil
 	}
 
 	if userInfo.Email != "" {
@@ -473,10 +503,11 @@ func (a *Auth) OAuth2Authenticate(ctx context.Context, provider string, userInfo
 			u, err := a.Repo.UserUpdate(ctx, user)
 			if err != nil {
 				xlog.Error("failed to link provider to existing user", "user_id", user.ID, "provider", provider, "err", err)
-				return nil, err
+				return nil, false, err
 			}
 			xlog.Info("linked provider to existing user", "user_id", user.ID, "provider", provider)
-			return u, nil
+			_ = CallHookWithProvider(a.Hooks.OnOAuth2SignedIn, ctx, u, provider)
+			return u, false, nil
 		}
 	}
 
@@ -490,10 +521,14 @@ func (a *Auth) OAuth2Authenticate(ctx context.Context, provider string, userInfo
 	u, err := a.Repo.UserCreate(ctx, user)
 	if err != nil {
 		xlog.Error("failed to create user from oauth2", "provider", provider, "err", err)
-		return nil, err
+		return nil, false, err
 	}
 	xlog.Info("created new user via oauth2", "user_id", u.ID, "provider", provider)
-	return u, nil
+
+	_ = CallHookWithProvider(a.Hooks.OnOAuth2Created, ctx, u, provider)
+	_ = CallHookWithProvider(a.Hooks.OnOAuth2SignedIn, ctx, u, provider)
+
+	return u, true, nil
 }
 
 // TokenResponse defines the structure of the token response.
@@ -580,7 +615,11 @@ func (a *Auth) TokenRefresh(ctx context.Context, refreshToken string) (*TokenRes
 		return nil, err
 	}
 
-	return a.TokenCreate(ctx, user)
+	resp, err := a.TokenCreate(ctx, user)
+	if err == nil {
+		_ = CallHook(a.Hooks.OnUserTokenRefreshed, ctx, user)
+	}
+	return resp, err
 }
 
 // TokenRevoke revokes the given refresh token.

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -320,9 +320,12 @@ func TestOAuth2Authenticate(t *testing.T) {
 			ID:    providerID,
 			Email: util.UniqueEmail("google"),
 		}
-		user, err := auth.OAuth2Authenticate(ctx, "google", userInfo)
+		user, isNew, err := auth.OAuth2Authenticate(ctx, "google", userInfo)
 		if err != nil {
 			t.Fatalf("OAuth2Authenticate failed: %v", err)
+		}
+		if !isNew {
+			t.Error("expected isNew to be true")
 		}
 		if user.Email != userInfo.Email {
 			t.Errorf("expected email %s, got %s", userInfo.Email, user.Email)
@@ -344,9 +347,12 @@ func TestOAuth2Authenticate(t *testing.T) {
 			ID:    providerID,
 			Email: updatedEmail,
 		}
-		user, err := auth.OAuth2Authenticate(ctx, "google", userInfo)
+		user, isNew, err := auth.OAuth2Authenticate(ctx, "google", userInfo)
 		if err != nil {
 			t.Fatalf("OAuth2Authenticate failed: %v", err)
+		}
+		if isNew {
+			t.Error("expected isNew to be false")
 		}
 		if user.Email != userInfo.Email {
 			t.Errorf("expected updated email %s, got %s", userInfo.Email, user.Email)
@@ -374,9 +380,12 @@ func TestOAuth2Authenticate(t *testing.T) {
 			ID:    githubProviderID,
 			Email: localEmail,
 		}
-		user, err := auth.OAuth2Authenticate(ctx, "github", userInfo)
+		user, isNew, err := auth.OAuth2Authenticate(ctx, "github", userInfo)
 		if err != nil {
 			t.Fatalf("OAuth2Authenticate failed: %v", err)
+		}
+		if isNew {
+			t.Error("expected isNew to be false")
 		}
 
 		if user.Email != localEmail {

--- a/pkg/service/hooks.go
+++ b/pkg/service/hooks.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+
+	"github.com/josuebrunel/ezauth/pkg/db/models"
+)
+
+// Hooks defines a set of function fields that can be used to react to authentication events.
+type Hooks struct {
+	OnUserCreated            func(ctx context.Context, user *models.User) error
+	OnUserUpdated            func(ctx context.Context, user *models.User) error
+	OnUserDeleted            func(ctx context.Context, user *models.User) error
+	OnUserSignedIn           func(ctx context.Context, user *models.User) error
+	OnUserSignedOut          func(ctx context.Context, user *models.User) error
+	OnUserTokenRefreshed     func(ctx context.Context, user *models.User) error
+	OnPasswordResetRequested func(ctx context.Context, user *models.User) error
+	OnPasswordResetConfirmed func(ctx context.Context, user *models.User) error
+	OnPasswordlessRequested  func(ctx context.Context, user *models.User) error
+	OnPasswordlessSignedIn   func(ctx context.Context, user *models.User) error
+	OnOAuth2SignedIn         func(ctx context.Context, user *models.User, provider string) error
+	OnOAuth2Created          func(ctx context.Context, user *models.User, provider string) error
+}
+
+// CallHook is a nil-safe helper to call a hook function.
+func CallHook[T any](fn func(context.Context, T) error, ctx context.Context, arg T) error {
+	if fn == nil {
+		return nil
+	}
+	return fn(ctx, arg)
+}
+
+// CallHookWithProvider is a nil-safe helper to call a hook function with an additional provider argument.
+func CallHookWithProvider[T any](fn func(context.Context, T, string) error, ctx context.Context, arg T, provider string) error {
+	if fn == nil {
+		return nil
+	}
+	return fn(ctx, arg, provider)
+}

--- a/pkg/service/hooks_test.go
+++ b/pkg/service/hooks_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/josuebrunel/ezauth/pkg/db/models"
+)
+
+func TestHooks(t *testing.T) {
+	ctx := context.Background()
+	user := &models.User{Email: "test@example.com"}
+
+	t.Run("nil hooks should not panic", func(t *testing.T) {
+		hooks := &Hooks{}
+		err := CallHook(hooks.OnUserCreated, ctx, user)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		err = CallHookWithProvider(hooks.OnOAuth2SignedIn, ctx, user, "google")
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("hooks should be called", func(t *testing.T) {
+		called := false
+		hooks := &Hooks{
+			OnUserCreated: func(ctx context.Context, u *models.User) error {
+				called = true
+				if u.Email != user.Email {
+					t.Errorf("expected email %s, got %s", user.Email, u.Email)
+				}
+				return nil
+			},
+		}
+
+		err := CallHook(hooks.OnUserCreated, ctx, user)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !called {
+			t.Error("expected hook to be called")
+		}
+	})
+
+	t.Run("hooks with provider should be called", func(t *testing.T) {
+		called := false
+		providerName := "google"
+		hooks := &Hooks{
+			OnOAuth2SignedIn: func(ctx context.Context, u *models.User, p string) error {
+				called = true
+				if p != providerName {
+					t.Errorf("expected provider %s, got %s", providerName, p)
+				}
+				return nil
+			},
+		}
+
+		err := CallHookWithProvider(hooks.OnOAuth2SignedIn, ctx, user, providerName)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !called {
+			t.Error("expected hook to be called")
+		}
+	})
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -12,6 +12,7 @@ type Auth struct {
 	Repo       *repository.Repository
 	Mailer     Mailer
 	PathPrefix string
+	Hooks      *Hooks
 }
 
 // New creates a new Auth service with the given config and repository.
@@ -28,6 +29,7 @@ func New(cfg *config.Config, repo *repository.Repository, pathPrefix string) *Au
 		Repo:       repo,
 		Mailer:     mailer,
 		PathPrefix: pathPrefix,
+		Hooks:      &Hooks{},
 	}
 }
 


### PR DESCRIPTION
Implemented a lightweight, synchronous hook system for `ezauth` that allows developers to react to key authentication events (e.g., `OnUserCreated`, `OnUserSignedIn`, `OnPasswordResetRequested`). Hooks are centralized in the service layer where possible to ensure consistent behavior across both API and Form-based authentication flows. The system is designed with a simple API surface, using function fields on a `Hooks` struct that default to `nil` (no-op). Comprehensive unit tests were added to verify hook invocation and nil-safety. Documentation has been updated in both the main README and the library documentation.

---
*PR created automatically by Jules for task [15437036928408739181](https://jules.google.com/task/15437036928408739181) started by @josuebrunel*